### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:jessie
+
+RUN BUILD_PACKAGES="curl wget" && \
+    apt-get update && \
+    apt-get install -y $BUILD_PACKAGES
+
+RUN wget $(curl -s https://api.github.com/repos/bcicen/ctop/releases/latest | \
+        grep 'browser_' | cut -d\" -f4 | \
+        grep 'linux-amd64') \
+    -O /usr/local/bin/ctop && \
+    chmod +x /usr/local/bin/ctop
+
+RUN AUTO_ADDED_PACKAGES=`apt-mark showauto` && \
+    apt-get remove --purge -y $BUILD_PACKAGES $AUTO_ADDED_PACKAGES
+
+
+CMD ["ctop"]


### PR DESCRIPTION
This seems to work.

Build: `docker build -t ctop .`

Run: `docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock ctop`

I'd rather use `alpine` for a smaller image, but it didn't run. Might be musl vs glibc differences. I'm not sure.