### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,12 @@ FROM debian:jessie
 
 RUN BUILD_PACKAGES="curl wget" && \
     apt-get update && \
-    apt-get install -y $BUILD_PACKAGES
-
-RUN wget $(curl -s https://api.github.com/repos/bcicen/ctop/releases/latest | \
-        grep 'browser_' | cut -d\" -f4 | \
-        grep 'linux-amd64') \
-    -O /usr/local/bin/ctop && \
-    chmod +x /usr/local/bin/ctop
-
-RUN AUTO_ADDED_PACKAGES=`apt-mark showauto` && \
+    apt-get install -y $BUILD_PACKAGES && \
+    wget $(curl -s https://api.github.com/repos/bcicen/ctop/releases/latest | \
+           grep 'browser_' | cut -d\" -f4 |grep 'linux-amd64') \
+      -O /usr/local/bin/ctop && \
+    chmod +x /usr/local/bin/ctop &&
+    AUTO_ADDED_PACKAGES=`apt-mark showauto` && \
     apt-get remove --purge -y $BUILD_PACKAGES $AUTO_ADDED_PACKAGES
-
 
 CMD ["ctop"]


### PR DESCRIPTION
It may not be as easy to read, but combining the three RUN statements together saves you some substantial megabytes:

    ctop_deb_orig        latest              149596353f88        4 seconds ago       187 MB
    ctop_deb_new        latest              d01f954b3adc        2 minutes ago       139 MB

This is because each RUN statement is creating a whole new layer in the image, so you're actually hanging on to all the stuff you were trying to get rid of!

Scott