### PR TITLE
Improve suggested "docker run" cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ sudo chmod +x /usr/local/bin/ctop
 
 or run via Docker:
 ```bash
-docker run -ti -v /var/run/docker.sock:/var/run/docker.sock quay.io/vektorlab/ctop:latest
+docker run -ti --name ctop --rm -v /var/run/docker.sock:/var/run/docker.sock quay.io/vektorlab/ctop:latest
 ```
 
 `ctop` is also available for Arch in the [AUR](https://aur.archlinux.org/packages/ctop/)


### PR DESCRIPTION
- make it use a given name "ctop"
- make it feasible for an `alias`