### PR TITLE
change glide to github repo, url is expired.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ docker run -ti --name ctop --rm -v /var/run/docker.sock:/var/run/docker.sock qua
 
 ## Building
 
-To build `ctop` from source, ensure you have a recent version of [glide](http://glide.sh/) installed and run:
+To build `ctop` from source, ensure you have a recent version of [glide](https://github.com/Masterminds/glide) installed and run:
 
 ```bash
 git clone https://github.com/bcicen/ctop.git $GOPATH/src/github.com/bcicen/ctop && \


### PR DESCRIPTION
glide.sh is not resolving for me. Whois returns:

whois glide.sh

Domain : glide.sh
Status : pendingDelete
Expiry : 2017-02-16
Delete : 2017-05-18 00:30


Domain reserved