### PR TITLE
change runC default path to PATH environment variables

### DIFF
--- a/_docs/connectors.md
+++ b/_docs/connectors.md
@@ -22,5 +22,5 @@ Using this connector requires full privileges to the local runC root dir (defaul
 
 Var | Description
 --- | ---
-RUNC_ROOT | path to runc root (default: `/run/runc`)
+RUNC_ROOT | path to runc root (default: from PATH environment variable)
 RUNC_SYSTEMD_CGROUP | if set, enable systemd cgroups

--- a/connector/runc.go
+++ b/connector/runc.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sync"
 	"time"
@@ -26,7 +27,7 @@ func NewRuncOpts() (RuncOpts, error) {
 	// read runc root path
 	root := os.Getenv("RUNC_ROOT")
 	if root == "" {
-		root = "/run/runc"
+		root, _ = exec.LookPath("runc")
 	}
 	abs, err := filepath.Abs(root)
 	if err != nil {


### PR DESCRIPTION
It's very practical if we can set runC path from PATH environment variables as default setting.