### PR TITLE
update RUNC_ROOT description to adjust to runC man

### DIFF
--- a/_docs/connectors.md
+++ b/_docs/connectors.md
@@ -16,11 +16,11 @@ DOCKER_HOST | Daemon socket to connect to (default: `unix://var/run/docker.sock`
 
 ## RunC
 
-Using this connector requires full privileges to the local runC root dir (default: `/run/runc`)
+Using this connector requires full privileges to the local runC root dir of container state (default: `/run/runc`)
 
 #### Options
 
 Var | Description
 --- | ---
-RUNC_ROOT | path to runc root (default: `/run/runc`)
+RUNC_ROOT | path to runc root for container state (default: `/run/runc`)
 RUNC_SYSTEMD_CGROUP | if set, enable systemd cgroups


### PR DESCRIPTION
RUNC_ROOT locates runC root dir of container state.
And so,  I update description of RUNC_ROOT although it is a trivial matter.