### PR TITLE
Feature: add more commands in container manager menu

### DIFF
--- a/connector/manager/docker.go
+++ b/connector/manager/docker.go
@@ -42,3 +42,24 @@ func (dc *Docker) Remove() error {
 	}
 	return nil
 }
+
+func (dc *Docker) Pause() error {
+	if err := dc.client.PauseContainer(dc.id); err != nil {
+		return fmt.Errorf("cannot pause container: %v", err)
+	}
+	return nil
+}
+
+func (dc *Docker) Unpause() error {
+	if err := dc.client.UnpauseContainer(dc.id); err != nil {
+		return fmt.Errorf("cannot unpause container: %v", err)
+	}
+	return nil
+}
+
+func (dc *Docker) Restart() error {
+	if err := dc.client.RestartContainer(dc.id, 3); err != nil {
+		return fmt.Errorf("cannot restart container: %v", err)
+	}
+	return nil
+}

--- a/connector/manager/main.go
+++ b/connector/manager/main.go
@@ -4,4 +4,7 @@ type Manager interface {
 	Start() error
 	Stop() error
 	Remove() error
+	Pause() error
+	Unpause() error
+	Restart() error
 }

--- a/connector/manager/mock.go
+++ b/connector/manager/mock.go
@@ -17,3 +17,15 @@ func (m *Mock) Stop() error {
 func (m *Mock) Remove() error {
 	return nil
 }
+
+func (m *Mock) Pause() error {
+	return nil
+}
+
+func (m *Mock) Unpause() error {
+	return nil
+}
+
+func (m *Mock) Restart() error {
+	return nil
+}

--- a/connector/manager/runc.go
+++ b/connector/manager/runc.go
@@ -17,3 +17,15 @@ func (rc *Runc) Stop() error {
 func (rc *Runc) Remove() error {
 	return nil
 }
+
+func (rc *Runc) Pause() error {
+	return nil
+}
+
+func (rc *Runc) Unpause() error {
+	return nil
+}
+
+func (rc *Runc) Restart() error {
+	return nil
+}

--- a/container/main.go
+++ b/container/main.go
@@ -117,3 +117,35 @@ func (c *Container) Remove() {
 		log.StatusErr(err)
 	}
 }
+
+func (c *Container) Pause() {
+	if c.Meta["state"] == "running" {
+		if err := c.manager.Pause(); err != nil {
+			log.Warningf("container %s: %v", c.Id, err)
+			log.StatusErr(err)
+			return
+		}
+		c.SetState("paused")
+	}
+}
+
+func (c *Container) Unpause() {
+	if c.Meta["state"] == "paused" {
+		if err := c.manager.Unpause(); err != nil {
+			log.Warningf("container %s: %v", c.Id, err)
+			log.StatusErr(err)
+			return
+		}
+		c.SetState("running")
+	}
+}
+
+func (c *Container) Restart() {
+	if c.Meta["state"] == "running" {
+		if err := c.manager.Restart(); err != nil {
+			log.Warningf("container %s: %v", c.Id, err)
+			log.StatusErr(err)
+			return
+		}
+	}
+}

--- a/menus.go
+++ b/menus.go
@@ -132,10 +132,15 @@ func ContainerMenu() MenuFn {
 
 	if c.Meta["state"] == "running" {
 		items = append(items, menu.Item{Val: "stop", Label: "stop"})
+		items = append(items, menu.Item{Val: "pause", Label: "pause"})
+		items = append(items, menu.Item{Val: "restart", Label: "restart"})
 	}
 	if c.Meta["state"] == "exited" || c.Meta["state"] == "created" {
 		items = append(items, menu.Item{Val: "start", Label: "start"})
 		items = append(items, menu.Item{Val: "remove", Label: "remove"})
+	}
+	if c.Meta["state"] == "paused" {
+		items = append(items, menu.Item{Val: "unpause", Label: "unpause"})
 	}
 	items = append(items, menu.Item{Val: "cancel", Label: "cancel"})
 
@@ -157,6 +162,12 @@ func ContainerMenu() MenuFn {
 			nextMenu = Confirm(confirmTxt("stop", c.GetMeta("name")), c.Stop)
 		case "remove":
 			nextMenu = Confirm(confirmTxt("remove", c.GetMeta("name")), c.Remove)
+		case "pause":
+			nextMenu = Confirm(confirmTxt("pause", c.GetMeta("name")), c.Pause)
+		case "unpause":
+			nextMenu = Confirm(confirmTxt("unpause", c.GetMeta("name")), c.Unpause)
+		case "restart":
+			nextMenu = Confirm(confirmTxt("restart", c.GetMeta("name")), c.Restart)
 		}
 		ui.StopLoop()
 	})


### PR DESCRIPTION
Signed-off-by: xiechengsheng <XIE1995@whut.edu.cn>

This pr adds more commands in container manager menu, such as pause/unpause, and restart, so that we could manage more container states.