### PR TITLE
add IP of networks in single view mode

### DIFF
--- a/connector/docker.go
+++ b/connector/docker.go
@@ -80,6 +80,17 @@ func portsFormat(ports map[api.Port][]api.PortBinding) string {
 	return strings.Join(append(exposed, published...), "\n")
 }
 
+func ipsFormat(networks map[string]api.ContainerNetwork) string {
+	var ips []string
+
+	for k, v := range networks {
+		s := fmt.Sprintf("%s:%s", k, v.IPAddress)
+		ips = append(ips, s)
+	}
+
+	return strings.Join(ips, "\n")
+}
+
 func (cm *Docker) refresh(c *container.Container) {
 	insp := cm.inspect(c.Id)
 	// remove container if no longer exists
@@ -89,6 +100,7 @@ func (cm *Docker) refresh(c *container.Container) {
 	}
 	c.SetMeta("name", shortName(insp.Name))
 	c.SetMeta("image", insp.Config.Image)
+	c.SetMeta("IPs", ipsFormat(insp.NetworkSettings.Networks))
 	c.SetMeta("ports", portsFormat(insp.NetworkSettings.Ports))
 	c.SetMeta("created", insp.Created.Format("Mon Jan 2 15:04:05 2006"))
 	c.SetMeta("health", insp.State.Health.Status)

--- a/cwidgets/single/info.go
+++ b/cwidgets/single/info.go
@@ -6,7 +6,7 @@ import (
 	ui "github.com/gizak/termui"
 )
 
-var displayInfo = []string{"id", "name", "image", "ports", "state", "created", "health"}
+var displayInfo = []string{"id", "name", "image", "ports", "IPs", "state", "created", "health"}
 
 type Info struct {
 	*ui.Table
@@ -45,7 +45,7 @@ func mkInfoRows(k, v string) (rows [][]string) {
 	// initial row with field name
 	rows = append(rows, []string{k, lines[0]})
 
-	// append any additional lines in seperate row
+	// append any additional lines in separate row
 	if len(lines) > 1 {
 		for _, line := range lines[1:] {
 			if line != "" {


### PR DESCRIPTION
With Ctop utility, we have already a lot of information without any need to call docker cli.
Thanks for this great utility.

However, sometimes, I still need to do a docker inspect to retrieve/check networks/IPs of container.

The aim of the PR is to show this information directly in the single view screen so we got all we need (IMHO).

regards,