### PR TITLE
Display environment variables on single view page

### DIFF
--- a/connector/docker.go
+++ b/connector/docker.go
@@ -104,6 +104,9 @@ func (cm *Docker) refresh(c *container.Container) {
 	c.SetMeta("ports", portsFormat(insp.NetworkSettings.Ports))
 	c.SetMeta("created", insp.Created.Format("Mon Jan 2 15:04:05 2006"))
 	c.SetMeta("health", insp.State.Health.Status)
+	for _, env := range insp.Config.Env {
+		c.SetMeta("[ENV-VAR]", string(env))
+	}
 	c.SetState(insp.State.Status)
 }
 

--- a/cwidgets/single/env.go
+++ b/cwidgets/single/env.go
@@ -1,0 +1,36 @@
+package single
+
+import (
+	ui "github.com/gizak/termui"
+	"regexp"
+)
+
+var envPattern = regexp.MustCompile(`(?P<KEY>[^=]+)=(?P<VALUJE>.*)`)
+
+type Env struct {
+	*ui.Table
+	data map[string]string
+}
+
+func NewEnv() *Env {
+	p := ui.NewTable()
+	p.Height = 4
+	p.Width = colWidth[0]
+	p.FgColor = ui.ThemeAttr("par.text.fg")
+	p.Separator = false
+	i := &Env{p, make(map[string]string)}
+	i.BorderLabel = "Env"
+	return i
+}
+
+func (w *Env) Set(k, v string) {
+	match := envPattern.FindStringSubmatch(v)
+	key := match[1]
+	value := match[2]
+	w.data[key] = value
+
+	w.Rows = [][]string{}
+	w.Rows = append(w.Rows, mkInfoRows(key, value)...)
+
+	w.Height = len(w.Rows) + 2
+}

--- a/cwidgets/single/main.go
+++ b/cwidgets/single/main.go
@@ -18,6 +18,7 @@ type Single struct {
 	Cpu   *Cpu
 	Mem   *Mem
 	IO    *IO
+	Env   *Env
 	X, Y  int
 	Width int
 }
@@ -32,6 +33,7 @@ func NewSingle(id string) *Single {
 		Cpu:   NewCpu(),
 		Mem:   NewMem(),
 		IO:    NewIO(),
+		Env:   NewEnv(),
 		Width: ui.TermWidth(),
 	}
 }
@@ -52,8 +54,14 @@ func (e *Single) Down() {
 	}
 }
 
-func (e *Single) SetWidth(w int)      { e.Width = w }
-func (e *Single) SetMeta(k, v string) { e.Info.Set(k, v) }
+func (e *Single) SetWidth(w int) { e.Width = w }
+func (e *Single) SetMeta(k, v string) {
+	if k == "[ENV-VAR]" {
+		e.Env.Set(k, v)
+	} else {
+		e.Info.Set(k, v)
+	}
+}
 
 func (e *Single) SetMetrics(m models.Metrics) {
 	e.Cpu.Update(m.CPUUtil)
@@ -69,6 +77,7 @@ func (e *Single) GetHeight() (h int) {
 	h += e.Cpu.Height
 	h += e.Mem.Height
 	h += e.IO.Height
+	h += e.Env.Height
 	return h
 }
 
@@ -103,6 +112,7 @@ func (e *Single) Buffer() ui.Buffer {
 	buf.Merge(e.Mem.Buffer())
 	buf.Merge(e.Net.Buffer())
 	buf.Merge(e.IO.Buffer())
+	buf.Merge(e.Env.Buffer())
 	return buf
 }
 
@@ -113,6 +123,7 @@ func (e *Single) all() []ui.GridBufferer {
 		e.Mem,
 		e.Net,
 		e.IO,
+		e.Env,
 	}
 }
 


### PR DESCRIPTION
Creates a new table on single view page and prints environment variables from docker inspect.