### PR TITLE
Increased line amount for tail

### DIFF
--- a/connector/collector/docker_logs.go
+++ b/connector/collector/docker_logs.go
@@ -37,7 +37,7 @@ func (l *DockerLogs) Stream() chan models.Log {
 		ErrorStream:  w,
 		Stdout:       true,
 		Stderr:       true,
-		Tail:         "10",
+		Tail:         "100",
 		Follow:       true,
 		Timestamps:   true,
 	}


### PR DESCRIPTION
When you want to check logs and figure out what was happened it difficult if you check only 10 last lines. 

Probably it would be more efficient to show at least 100 lines. 