### PR TITLE
Updated to golang 1.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/vektorcloud/go:1.12
+FROM quay.io/vektorcloud/go:1.14
 
 RUN apk add --no-cache make
 


### PR DESCRIPTION
Signed-off-by: Daniel Sutton <daniel@ducksecops.uk>

Updated dockerfile to use golang 1.14 as 1.12 is now end of life. Thank you for the excellent project.