### PR TITLE
Fix config encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Option | Description
 `-s`  | select initial container sort field
 `-scale-cpu`	| show cpu as % of system total
 `-v`	| output version information and exit
-`-shell` | specify shell (default: sh)
+`-shell` | exec shell to use (default: sh)
 
 ### Keybindings
 

--- a/config/file.go
+++ b/config/file.go
@@ -90,6 +90,13 @@ func Write() (path string, err error) {
 		}
 	}
 
+	// remove prior to writing new file
+	if err := os.Remove(path); err != nil {
+		if !os.IsNotExist(err) {
+			return path, err
+		}
+	}
+
 	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return path, fmt.Errorf("failed to open config for writing: %s", err)

--- a/connector/manager/main.go
+++ b/connector/manager/main.go
@@ -1,5 +1,9 @@
 package manager
 
+import "errors"
+
+var ActionNotImplErr = errors.New("action not implemented")
+
 type Manager interface {
 	Start() error
 	Stop() error

--- a/connector/manager/mock.go
+++ b/connector/manager/mock.go
@@ -7,29 +7,29 @@ func NewMock() *Mock {
 }
 
 func (m *Mock) Start() error {
-	return nil
+	return ActionNotImplErr
 }
 
 func (m *Mock) Stop() error {
-	return nil
+	return ActionNotImplErr
 }
 
 func (m *Mock) Remove() error {
-	return nil
+	return ActionNotImplErr
 }
 
 func (m *Mock) Pause() error {
-	return nil
+	return ActionNotImplErr
 }
 
 func (m *Mock) Unpause() error {
-	return nil
+	return ActionNotImplErr
 }
 
 func (m *Mock) Restart() error {
-	return nil
+	return ActionNotImplErr
 }
 
 func (m *Mock) Exec(cmd []string) error {
-	return nil
+	return ActionNotImplErr
 }

--- a/connector/manager/runc.go
+++ b/connector/manager/runc.go
@@ -7,29 +7,29 @@ func NewRunc() *Runc {
 }
 
 func (rc *Runc) Start() error {
-	return nil
+	return ActionNotImplErr
 }
 
 func (rc *Runc) Stop() error {
-	return nil
+	return ActionNotImplErr
 }
 
 func (rc *Runc) Remove() error {
-	return nil
+	return ActionNotImplErr
 }
 
 func (rc *Runc) Pause() error {
-	return nil
+	return ActionNotImplErr
 }
 
 func (rc *Runc) Unpause() error {
-	return nil
+	return ActionNotImplErr
 }
 
 func (rc *Runc) Restart() error {
-	return nil
+	return ActionNotImplErr
 }
 
 func (rc *Runc) Exec(cmd []string) error {
-	return nil
+	return ActionNotImplErr
 }

--- a/main.go
+++ b/main.go
@@ -65,7 +65,9 @@ func main() {
 
 	// init global config and read config file if exists
 	config.Init()
-	config.Read()
+	if err := config.Read(); err != nil {
+		log.Warningf("reading config: %s", err)
+	}
 
 	// override default config values with command line flags
 	if *filterFlag != "" {

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func main() {
 		invertFlag      = flag.Bool("i", false, "invert default colors")
 		scaleCpu        = flag.Bool("scale-cpu", false, "show cpu as % of system total")
 		connectorFlag   = flag.String("connector", "docker", "container connector to use")
-		defaultShell    = flag.String("shell", "", "default shell")
+		defaultShell    = flag.String("shell", "sh", "exec shell to use")
 	)
 	flag.Parse()
 


### PR DESCRIPTION
Ensure existing config file is removed prior to writing. Writing atop an existing (larger) config file will otherwise include trailing content from previous revision