### PR TITLE
text.go: to do not manually truncate id and name columns

### DIFF
--- a/cwidgets/compact/text.go
+++ b/cwidgets/compact/text.go
@@ -19,10 +19,6 @@ func NewNameCol() CompactCol {
 
 func (w *NameCol) SetMeta(m models.Meta) {
 	w.Text = m.Get("name")
-	// truncate container id
-	if len(w.Text) > 12 {
-		w.Text = w.Text[:12]
-	}
 }
 
 type CIDCol struct {
@@ -35,9 +31,6 @@ func NewCIDCol() CompactCol {
 
 func (w *CIDCol) SetMeta(m models.Meta) {
 	w.Text = m.Get("id")
-	if len(w.Text) > 12 {
-		w.Text = w.Text[:12]
-	}
 }
 
 type NetCol struct {


### PR DESCRIPTION
This truncation is already handled by termui:

![screenshot of new truncation](https://user-images.githubusercontent.com/415502/97179928-1aff1e80-17a2-11eb-8342-8cac34dd0c43.png)
