### PR TITLE
Add apt azlux's repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,17 @@ as well as a [single container view][single_view] for inspecting a specific cont
 
 Fetch the [latest release](https://github.com/bcicen/ctop/releases) for your platform:
 
-#### Linux
+#### Debian/Ubuntu
+
+Maintained by a (third party)[https://packages.azlux.fr/]
+```bash
+echo "deb http://packages.azlux.fr/debian/ buster main" | sudo tee /etc/apt/sources.list.d/azlux.list
+wget -qO - https://azlux.fr/repo.gpg.key | sudo apt-key add -
+sudo apt update
+sudo apt install docker-ctop
+```
+
+#### Linux (Generic)
 
 ```bash
 sudo wget https://github.com/bcicen/ctop/releases/download/v0.7.4/ctop-0.7.4-linux-amd64 -O /usr/local/bin/ctop


### PR DESCRIPTION
Related to https://github.com/bcicen/ctop/issues/179
This commit add my repo as tiers party repo.
This way, people have auto-update with apt. And they are aware that it's not maintained by you.

On the repo, all script are [public](http://packages.azlux.fr/scripts/) , there are running every night, so update are ready every night based on github releases.