### PR TITLE
Improve docker events handling

### DIFF
--- a/connector/docker.go
+++ b/connector/docker.go
@@ -17,7 +17,7 @@ func init() { enabled["docker"] = NewDocker }
 var actionToStatus = map[string]string{
 	"create":  "created",
 	"start":   "running",
-	"kill":    "exited",
+	"die":     "exited",
 	"stop":    "exited",
 	"pause":   "paused",
 	"unpause": "running",

--- a/connector/docker.go
+++ b/connector/docker.go
@@ -2,6 +2,7 @@ package connector
 
 import (
 	"fmt"
+	"github.com/op/go-logging"
 	"strings"
 	"sync"
 
@@ -71,10 +72,14 @@ func (cm *Docker) watchEvents() {
 
 		switch actionName {
 		case "start", "die", "pause", "unpause", "health_status":
-			log.Debugf("handling docker event: action=%s id=%s", e.Action, e.ID)
+			if log.IsEnabledFor(logging.DEBUG) {
+				log.Debugf("handling docker event: action=%s id=%s", e.Action, e.ID)
+			}
 			cm.needsRefresh <- e.ID
 		case "destroy":
-			log.Debugf("handling docker event: action=%s id=%s", e.Action, e.ID)
+			if log.IsEnabledFor(logging.DEBUG) {
+				log.Debugf("handling docker event: action=destroy id=%s", e.ID)
+			}
 			cm.delByID(e.ID)
 		}
 	}

--- a/connector/docker.go
+++ b/connector/docker.go
@@ -87,7 +87,11 @@ func (cm *Docker) watchEvents() {
 		}
 
 		actionName := e.Action
-		// Action may have additional param: "exec_create: redis-cli ping" or "health_status: healthy"
+		// fast skip all exec_* events: exec_create, exec_start, exec_die
+		if strings.HasPrefix(actionName, "exec_") {
+			continue
+		}
+		// Action may have additional param i.e. "health_status: healthy"
 		// We need to strip to have only action name
 		sepIdx := strings.Index(actionName, ": ")
 		if sepIdx != -1 {

--- a/connector/docker.go
+++ b/connector/docker.go
@@ -68,7 +68,13 @@ func (cm *Docker) watchEvents() {
 			continue
 		}
 
-		actionName := strings.Split(e.Action, ":")[0]
+		actionName := e.Action
+		// Action may have additional param: "exec_create: redis-cli ping" or "health_status: healthy"
+		// We need to strip to have only action name
+		sepIdx := strings.Index(actionName, ": ")
+		if sepIdx != -1 {
+			actionName = actionName[:sepIdx]
+		}
 
 		switch actionName {
 		case "start", "die", "pause", "unpause", "health_status":

--- a/debug.go
+++ b/debug.go
@@ -12,6 +12,10 @@ import (
 var mstats = &runtime.MemStats{}
 
 func logEvent(e ui.Event) {
+	// skip timer events e.g. /timer/1s
+	if e.From == "timer" {
+		return
+	}
 	var s string
 	s += fmt.Sprintf("Type=%s", quote(e.Type))
 	s += fmt.Sprintf(" Path=%s", quote(e.Path))


### PR DESCRIPTION
There is a lot of events and their processing must be as fast as possible.
It turned out that events may lost if client is busy: docker server wont wait for a client.
The main idea is to minimize inspect calls if we just want to determine container's status.

This PR may partially fixes #187