### PR TITLE
logging: skip timer events e.g. /timer/1s

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -12,6 +12,10 @@ import (
 var mstats = &runtime.MemStats{}
 
 func logEvent(e ui.Event) {
+	// skip timer events e.g. /timer/1s
+	if e.From == "timer" {
+		return
+	}
 	var s string
 	s += fmt.Sprintf("Type=%s", quote(e.Type))
 	s += fmt.Sprintf(" Path=%s", quote(e.Path))


### PR DESCRIPTION
Each second we receive the timer event which makes little sense but log is bloated with the event.
To make logs more readable we can disable logging of this event