### PR TITLE
Exec shell config

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ Option | Description
 `-s`  | select initial container sort field
 `-scale-cpu`	| show cpu as % of system total
 `-v`	| output version information and exit
-`-shell` | exec shell to use (default: sh)
 
 ### Keybindings
 

--- a/config/param.go
+++ b/config/param.go
@@ -13,11 +13,6 @@ var defaultParams = []*Param{
 		Label: "Container Sort Field",
 	},
 	&Param{
-		Key:   "shell",
-		Val:   "sh",
-		Label: "Shell",
-	},
-	&Param{
 		Key:   "columns",
 		Val:   "status,name,id,cpu,mem,net,io,pids",
 		Label: "Enabled Columns",

--- a/main.go
+++ b/main.go
@@ -46,7 +46,6 @@ func main() {
 		invertFlag      = flag.Bool("i", false, "invert default colors")
 		scaleCpu        = flag.Bool("scale-cpu", false, "show cpu as % of system total")
 		connectorFlag   = flag.String("connector", "docker", "container connector to use")
-		defaultShell    = flag.String("shell", "", "exec shell to use")
 	)
 	flag.Parse()
 
@@ -89,10 +88,6 @@ func main() {
 
 	if *scaleCpu {
 		config.Toggle("scaleCpu")
-	}
-
-	if *defaultShell != "" {
-		config.Update("shell", *defaultShell)
 	}
 
 	// init ui

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func main() {
 		invertFlag      = flag.Bool("i", false, "invert default colors")
 		scaleCpu        = flag.Bool("scale-cpu", false, "show cpu as % of system total")
 		connectorFlag   = flag.String("connector", "docker", "container connector to use")
-		defaultShell    = flag.String("shell", "sh", "exec shell to use")
+		defaultShell    = flag.String("shell", "", "exec shell to use")
 	)
 	flag.Parse()
 

--- a/menus.go
+++ b/menus.go
@@ -358,8 +358,16 @@ func ExecShell() MenuFn {
 
 	ui.DefaultEvtStream.ResetHandlers()
 	defer ui.DefaultEvtStream.ResetHandlers()
-
-	if err := c.Exec([]string{"/bin/sh", "-c", "printf '\\e[0m\\e[?25h' && clear && /bin/sh"}); err != nil {
+	// Detect and execute default shell in container.
+	// Execute Ash shell command: /bin/sh -c
+	// Reset colors: printf '\e[0m\e[?25h'
+	// Clear screen
+	// Run default shell for the user. It's configured in /etc/passwd and looks like root:x:0:0:root:/root:/bin/bash:
+	//  1. Get current user id: id -un
+	//  2. Find user's line in /etc/passwd by grep
+	//  3. Extract default user's shell by cutting seven's column separated by :
+	//  4. Execute the shell path with eval
+	if err := c.Exec([]string{"/bin/sh", "-c", "printf '\\e[0m\\e[?25h' && clear && eval `grep ^$(id -un): /etc/passwd | cut -d : -f 7-`"}); err != nil {
 		log.StatusErr(err)
 	}
 

--- a/menus.go
+++ b/menus.go
@@ -359,8 +359,7 @@ func ExecShell() MenuFn {
 	ui.DefaultEvtStream.ResetHandlers()
 	defer ui.DefaultEvtStream.ResetHandlers()
 
-	shell := config.GetVal("shell")
-	if err := c.Exec([]string{shell, "-c", "printf '\\e[0m\\e[?25h' && clear && " + shell}); err != nil {
+	if err := c.Exec([]string{"/bin/sh", "-c", "printf '\\e[0m\\e[?25h' && clear && /bin/sh"}); err != nil {
 		log.StatusErr(err)
 	}
 

--- a/menus.go
+++ b/menus.go
@@ -359,8 +359,8 @@ func ExecShell() MenuFn {
 	ui.DefaultEvtStream.ResetHandlers()
 	defer ui.DefaultEvtStream.ResetHandlers()
 
-	shell := config.Get("shell")
-	if err := c.Exec([]string{shell.Val, "-c", "printf '\\e[0m\\e[?25h' && clear && " + shell.Val}); err != nil {
+	shell := config.GetVal("shell")
+	if err := c.Exec([]string{shell, "-c", "printf '\\e[0m\\e[?25h' && clear && " + shell}); err != nil {
 		log.Fatal(err)
 	}
 

--- a/menus.go
+++ b/menus.go
@@ -361,7 +361,7 @@ func ExecShell() MenuFn {
 
 	shell := config.GetVal("shell")
 	if err := c.Exec([]string{shell, "-c", "printf '\\e[0m\\e[?25h' && clear && " + shell}); err != nil {
-		log.Fatal(err)
+		log.StatusErr(err)
 	}
 
 	return nil


### PR DESCRIPTION
I found a bug: we cant change `shell` config because it is always overwritten by command line `-shell` option which is by default `sh`. So first commit is to fix this behavior.
But this config makes little sense because some containers may have bash/zsh but most of them just using plain Ash/Dash from /bin/sh
In fact even different users may have different shells configured in `/etc/passwd`.
So I implemented autodetection of default shell and removed the `shell` config and option.
Unfortunately there is no an easy solution so I had to parse `/etc/passwd`.

I tested and on `mariadb` container opened bash while on `redis:alpine` opens just Ash.
You can check which shell is opened by executing 

     ps | grep `echo $$` | awk '{ print $4 }'

@fr05t1k you is an original author of the feature so please review