### PR TITLE
#207 Replace scaleCpu option with dedicated column CPU Scaled

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ Option | Description
 `-i`  | invert default colors
 `-r`	| reverse container sort order
 `-s`  | select initial container sort field
-`-scale-cpu`	| show cpu as % of system total
 `-v`	| output version information and exit
 
 ### Keybindings

--- a/config/columns.go
+++ b/config/columns.go
@@ -27,6 +27,11 @@ var defaultColumns = []Column{
 		Enabled: true,
 	},
 	Column{
+		Name:    "cpus",
+		Label:   "CPU Usage as % of system total",
+		Enabled: false,
+	},
+	Column{
 		Name:    "mem",
 		Label:   "Memory Usage",
 		Enabled: true,

--- a/config/switch.go
+++ b/config/switch.go
@@ -22,11 +22,6 @@ var defaultSwitches = []*Switch{
 		Val:   true,
 		Label: "Enable status header",
 	},
-	&Switch{
-		Key:   "scaleCpu",
-		Val:   false,
-		Label: "Show CPU as %% of system total",
-	},
 }
 
 type Switch struct {

--- a/cwidgets/compact/column.go
+++ b/cwidgets/compact/column.go
@@ -13,6 +13,7 @@ var (
 		"name":   NewNameCol,
 		"id":     NewCIDCol,
 		"cpu":    NewCPUCol,
+		"cpus":   NewCpuScaledCol,
 		"mem":    NewMemCol,
 		"net":    NewNetCol,
 		"io":     NewIOCol,

--- a/cwidgets/compact/gauge.go
+++ b/cwidgets/compact/gauge.go
@@ -24,10 +24,10 @@ func NewCpuScaledCol() CompactCol {
 
 func (w *CPUCol) SetMetrics(m models.Metrics) {
 	val := m.CPUUtil
+	w.BarColor = colorScale(val)
 	if !w.scaleCpu {
 		val = val * int(m.NCpus)
 	}
-	w.BarColor = colorScale(val)
 	w.Label = fmt.Sprintf("%d%%", val)
 
 	if val > 100 {

--- a/cwidgets/compact/gauge.go
+++ b/cwidgets/compact/gauge.go
@@ -11,14 +11,22 @@ import (
 
 type CPUCol struct {
 	*GaugeCol
+	scaleCpu bool
 }
 
 func NewCPUCol() CompactCol {
-	return &CPUCol{NewGaugeCol("CPU")}
+	return &CPUCol{NewGaugeCol("CPU"), false}
+}
+
+func NewCpuScaledCol() CompactCol {
+	return &CPUCol{NewGaugeCol("CPUS"), true}
 }
 
 func (w *CPUCol) SetMetrics(m models.Metrics) {
 	val := m.CPUUtil
+	if !w.scaleCpu {
+		val = val * int(m.NCpus)
+	}
 	w.BarColor = colorScale(val)
 	w.Label = fmt.Sprintf("%d%%", val)
 

--- a/main.go
+++ b/main.go
@@ -44,7 +44,6 @@ func main() {
 		sortFieldFlag   = flag.String("s", "", "select container sort field")
 		reverseSortFlag = flag.Bool("r", false, "reverse container sort order")
 		invertFlag      = flag.Bool("i", false, "invert default colors")
-		scaleCpu        = flag.Bool("scale-cpu", false, "show cpu as % of system total")
 		connectorFlag   = flag.String("connector", "docker", "container connector to use")
 	)
 	flag.Parse()
@@ -84,10 +83,6 @@ func main() {
 
 	if *reverseSortFlag {
 		config.Toggle("sortReversed")
-	}
-
-	if *scaleCpu {
-		config.Toggle("scaleCpu")
 	}
 
 	// init ui

--- a/models/main.go
+++ b/models/main.go
@@ -31,6 +31,7 @@ func (m Meta) Get(k string) string {
 }
 
 type Metrics struct {
+	NCpus        uint8
 	CPUUtil      int
 	NetTx        int64
 	NetRx        int64


### PR DESCRIPTION
Thus users can enable\disable this and save config.
The new column called `CPUS` i.e. CPU scaled and disabled by default.
FIXME For some reason it's shown as last column.


