### PR TITLE
Use more clear status marks

### DIFF
--- a/cwidgets/compact/status.go
+++ b/cwidgets/compact/status.go
@@ -22,11 +22,11 @@ type Status struct {
 func NewStatus() CompactCol {
 	s := &Status{
 		Block:  ui.NewBlock(),
+		status: []ui.Cell{{Ch: ' '}},
 		health: []ui.Cell{{Ch: ' '}},
 	}
 	s.Height = 1
 	s.Border = false
-	s.setState("")
 	return s
 }
 
@@ -51,17 +51,25 @@ func (s *Status) Header() string            { return "" }
 func (s *Status) FixedWidth() int           { return 3 }
 
 func (s *Status) setState(val string) {
-	// defaults
-	text := mark
 	color := ui.ColorDefault
+	var text string
 
 	switch val {
+	case "":
+		return
+	case "created":
+		text = mark
 	case "running":
+		text = mark
 		color = ui.ThemeAttr("status.ok")
 	case "exited":
+		text = mark
 		color = ui.ThemeAttr("status.danger")
 	case "paused":
 		text = vBar
+	default:
+		text = " "
+		log.Warningf("unknown status string: \"%v\"", val)
 	}
 
 	s.status = ui.TextCells(text, color, ui.ColorDefault)
@@ -69,18 +77,22 @@ func (s *Status) setState(val string) {
 
 func (s *Status) setHealth(val string) {
 	color := ui.ColorDefault
-	mark := healthMark
+	var mark string
 
 	switch val {
 	case "":
 		return
 	case "healthy":
+		mark = healthMark
 		color = ui.ThemeAttr("status.ok")
 	case "unhealthy":
+		mark = healthMark
 		color = ui.ThemeAttr("status.danger")
 	case "starting":
+		mark = healthMark
 		color = ui.ThemeAttr("status.warn")
 	default:
+		mark = " "
 		log.Warningf("unknown health state string: \"%v\"", val)
 	}
 

--- a/cwidgets/compact/status.go
+++ b/cwidgets/compact/status.go
@@ -6,12 +6,6 @@ import (
 	ui "github.com/gizak/termui"
 )
 
-const (
-	mark       = "◉"
-	healthMark = "✚"
-	vBar       = string('\u25AE') + string('\u25AE')
-)
-
 // Status indicator
 type Status struct {
 	*ui.Block
@@ -52,27 +46,27 @@ func (s *Status) FixedWidth() int           { return 3 }
 
 func (s *Status) setState(val string) {
 	color := ui.ColorDefault
-	var text string
+	var mark string
 
 	switch val {
 	case "":
 		return
 	case "created":
-		text = mark
+		mark = "◉"
 	case "running":
-		text = mark
+		mark = "⏵"
 		color = ui.ThemeAttr("status.ok")
 	case "exited":
-		text = mark
+		mark = "⏹"
 		color = ui.ThemeAttr("status.danger")
 	case "paused":
-		text = vBar
+		mark = "⏸"
 	default:
-		text = " "
+		mark = " "
 		log.Warningf("unknown status string: \"%v\"", val)
 	}
 
-	s.status = ui.TextCells(text, color, ui.ColorDefault)
+	s.status = ui.TextCells(mark, color, ui.ColorDefault)
 }
 
 func (s *Status) setHealth(val string) {
@@ -83,13 +77,13 @@ func (s *Status) setHealth(val string) {
 	case "":
 		return
 	case "healthy":
-		mark = healthMark
+		mark = "☼"
 		color = ui.ThemeAttr("status.ok")
 	case "unhealthy":
-		mark = healthMark
+		mark = "⚠"
 		color = ui.ThemeAttr("status.danger")
 	case "starting":
-		mark = healthMark
+		mark = "◌"
 		color = ui.ThemeAttr("status.warn")
 	default:
 		mark = " "

--- a/cwidgets/compact/status.go
+++ b/cwidgets/compact/status.go
@@ -32,16 +32,8 @@ func NewStatus() CompactCol {
 
 func (s *Status) Buffer() ui.Buffer {
 	buf := s.Block.Buffer()
-	x := 0
-	for _, c := range s.health {
-		buf.Set(s.InnerX()+x, s.InnerY(), c)
-		x += c.Width()
-	}
-	x += 1
-	for _, c := range s.status {
-		buf.Set(s.InnerX()+x, s.InnerY(), c)
-		x += c.Width()
-	}
+	buf.Set(s.InnerX(), s.InnerY(), s.health[0])
+	buf.Set(s.InnerX()+2, s.InnerY(), s.status[0])
 	return buf
 }
 


### PR DESCRIPTION
Instead of bullet for status and plus for health we can use more known symbols:

![screenshot gnome terminal](https://user-images.githubusercontent.com/415502/99967310-57716a80-2da0-11eb-8553-a50bc5e6906a.png)

I chose this symbols because they are part of Unicode 1993 and should be supported by all fonts.
* ☼ sun for healthy
* ⚠ warning for unhealthy
* ◌  dotet circle for starting

Please check how they looks in iTerm on OSX. Unfortunately they wont be shown correctly on Putty from windows because it uses Currier New font but previous statuses wasn't shown ether.
