### PR TITLE
Minimize expensive API calls

### DIFF
--- a/connector/docker.go
+++ b/connector/docker.go
@@ -110,6 +110,10 @@ func (cm *Docker) watchEvents() {
 			if log.IsEnabledFor(logging.DEBUG) {
 				log.Debugf("handling docker event: action=create id=%s", e.ID)
 			}
+			c := cm.MustGet(e.ID)
+			c.SetMeta("name", shortName(e.Actor.Attributes["name"]))
+			c.SetMeta("image", e.Actor.Attributes["image"])
+			c.SetState("created")
 			cm.needsRefresh <- e.ID
 		case "destroy":
 			if log.IsEnabledFor(logging.DEBUG) {

--- a/connector/docker.go
+++ b/connector/docker.go
@@ -135,38 +135,7 @@ func (cm *Docker) watchEvents() {
 }
 
 func (cm *Docker) refresh(c *container.Container) {
-	insp, found, failed := cm.inspect(c.Id)
-	if failed {
-		return
-	}
-	// remove container if no longer exists
-	if !found {
-		cm.delByID(c.Id)
-		return
-	}
-	c.SetMeta("name", manager.ShortName(insp.Name))
-	c.SetMeta("image", insp.Config.Image)
-	c.SetMeta("IPs", manager.IpsFormat(insp.NetworkSettings.Networks))
-	c.SetMeta("ports", manager.PortsFormat(insp.NetworkSettings.Ports))
-	c.SetMeta("created", insp.Created.Format("Mon Jan 2 15:04:05 2006"))
-	c.SetMeta("health", insp.State.Health.Status)
-	for _, env := range insp.Config.Env {
-		c.SetMeta("[ENV-VAR]", env)
-	}
-	c.SetState(insp.State.Status)
-}
-
-func (cm *Docker) inspect(id string) (insp *api.Container, found bool, failed bool) {
-	c, err := cm.client.InspectContainer(id)
-	if err != nil {
-		if _, notFound := err.(*api.NoSuchContainer); notFound {
-			return c, false, false
-		}
-		// other error e.g. connection failed
-		log.Errorf("%s (%T)", err.Error(), err)
-		return c, false, true
-	}
-	return c, true, false
+	cm.updateContainers(false, []string{c.Id})
 }
 
 // Mark all container IDs for refresh

--- a/connector/docker.go
+++ b/connector/docker.go
@@ -230,12 +230,16 @@ func parseStatusHealth(c *container.Container, status string) {
 }
 
 func (cm *Docker) Loop() {
+	ticker := time.NewTicker(5 * time.Minute)
 	for {
 		select {
+		case <-ticker.C:
+			cm.refreshAll()
 		case id := <-cm.needsRefresh:
 			c := cm.MustGet(id)
 			cm.refresh(c)
 		case <-cm.closed:
+			ticker.Stop()
 			return
 		}
 	}

--- a/connector/manager/docker.go
+++ b/connector/manager/docker.go
@@ -2,10 +2,16 @@ package manager
 
 import (
 	"fmt"
+	"github.com/bcicen/ctop/logging"
+	"github.com/bcicen/ctop/models"
 	api "github.com/fsouza/go-dockerclient"
 	"github.com/pkg/errors"
 	"io"
 	"os"
+)
+
+var (
+	log = logging.Init()
 )
 
 type Docker struct {
@@ -100,6 +106,39 @@ func (dc *Docker) Exec(cmd []string) error {
 		ErrorStream:  os.Stderr,
 		RawTerminal:  true,
 	})
+}
+
+func (dc *Docker) inspect(id string) (insp *api.Container, found bool, err error) {
+	c, err := dc.client.InspectContainer(id)
+	if err != nil {
+		if _, notFound := err.(*api.NoSuchContainer); notFound {
+			return c, false, nil
+		}
+		// other error e.g. connection failed
+		log.Errorf("%s (%T)", err.Error(), err)
+		return c, false, err
+	}
+	return c, true, nil
+}
+
+func (dc *Docker) Inspect() (models.Meta, error) {
+	insp, found, err := dc.inspect(dc.id)
+	if !found {
+		return nil, err
+	}
+	newMeta := models.Meta{}
+	newMeta["name"] = ShortName(insp.Name)
+	newMeta["image"] = insp.Config.Image
+	newMeta["IPs"] = IpsFormat(insp.NetworkSettings.Networks)
+	newMeta["ports"] = PortsFormat(insp.NetworkSettings.Ports)
+	newMeta["created"] = insp.Created.Format("Mon Jan 2 15:04:05 2006")
+	newMeta["health"] = insp.State.Health.Status
+	for _, env := range insp.Config.Env {
+		newMeta["[ENV-VAR]"] = env
+	}
+	newMeta["state"] = insp.State.Status
+
+	return newMeta, nil
 }
 
 func (dc *Docker) Start() error {

--- a/connector/manager/docker_utils.go
+++ b/connector/manager/docker_utils.go
@@ -1,0 +1,61 @@
+package manager
+
+import (
+	"fmt"
+	api "github.com/fsouza/go-dockerclient"
+	"strings"
+)
+
+func PortsFormat(ports map[api.Port][]api.PortBinding) string {
+	var exposed []string
+	var published []string
+
+	for k, v := range ports {
+		if len(v) == 0 {
+			// 3306/tcp
+			exposed = append(exposed, string(k))
+			continue
+		}
+		for _, binding := range v {
+			// 0.0.0.0:3307 -> 3306/tcp
+			s := fmt.Sprintf("%s:%s -> %s", binding.HostIP, binding.HostPort, k)
+			published = append(published, s)
+		}
+	}
+
+	return strings.Join(append(exposed, published...), "\n")
+}
+
+func PortsFormatArr(ports []api.APIPort) string {
+	var exposed []string
+	var published []string
+	for _, binding := range ports {
+		if binding.PublicPort != 0 {
+			// 0.0.0.0:3307 -> 3306/tcp
+			s := fmt.Sprintf("%s:%d -> %d/%s", binding.IP, binding.PublicPort, binding.PrivatePort, binding.Type)
+			published = append(published, s)
+		} else {
+			// 3306/tcp
+			s := fmt.Sprintf("%d/%s", binding.PrivatePort, binding.Type)
+			exposed = append(exposed, s)
+		}
+	}
+
+	return strings.Join(append(exposed, published...), "\n")
+}
+
+func IpsFormat(networks map[string]api.ContainerNetwork) string {
+	var ips []string
+
+	for k, v := range networks {
+		s := fmt.Sprintf("%s:%s", k, v.IPAddress)
+		ips = append(ips, s)
+	}
+
+	return strings.Join(ips, "\n")
+}
+
+// use primary container name
+func ShortName(name string) string {
+	return strings.TrimPrefix(name, "/")
+}

--- a/connector/manager/main.go
+++ b/connector/manager/main.go
@@ -1,6 +1,9 @@
 package manager
 
-import "errors"
+import (
+	"errors"
+	"github.com/bcicen/ctop/models"
+)
 
 var ActionNotImplErr = errors.New("action not implemented")
 
@@ -12,4 +15,5 @@ type Manager interface {
 	Unpause() error
 	Restart() error
 	Exec(cmd []string) error
+	Inspect() (models.Meta, error)
 }

--- a/connector/manager/mock.go
+++ b/connector/manager/mock.go
@@ -1,5 +1,7 @@
 package manager
 
+import models "github.com/bcicen/ctop/models"
+
 type Mock struct{}
 
 func NewMock() *Mock {
@@ -32,4 +34,8 @@ func (m *Mock) Restart() error {
 
 func (m *Mock) Exec(cmd []string) error {
 	return ActionNotImplErr
+}
+
+func (m *Mock) Inspect() (models.Meta, error) {
+	return nil, nil
 }

--- a/connector/manager/runc.go
+++ b/connector/manager/runc.go
@@ -1,5 +1,7 @@
 package manager
 
+import "github.com/bcicen/ctop/models"
+
 type Runc struct{}
 
 func NewRunc() *Runc {
@@ -32,4 +34,8 @@ func (rc *Runc) Restart() error {
 
 func (rc *Runc) Exec(cmd []string) error {
 	return ActionNotImplErr
+}
+
+func (rc *Runc) Inspect() (models.Meta, error) {
+	return nil, nil
 }

--- a/container/main.go
+++ b/container/main.go
@@ -58,6 +58,11 @@ func (c *Container) SetMeta(k, v string) {
 	c.updater.SetMeta(c.Meta)
 }
 
+func (c *Container) SetFullMeta(m models.Meta) {
+	c.Meta = m
+	c.updater.SetMeta(c.Meta)
+}
+
 func (c *Container) GetMeta(k string) string {
 	return c.Meta.Get(k)
 }
@@ -157,4 +162,14 @@ func (c *Container) Restart() {
 
 func (c *Container) Exec(cmd []string) error {
 	return c.manager.Exec(cmd)
+}
+
+func (c *Container) Inspect() {
+	inspectMeta, err := c.manager.Inspect()
+	if err != nil {
+		log.Warningf("container %s: %v", c.Id, err)
+		log.StatusErr(err)
+		return
+	}
+	c.SetFullMeta(inspectMeta)
 }

--- a/grid.go
+++ b/grid.go
@@ -85,6 +85,7 @@ func SingleView() MenuFn {
 
 	ex := single.NewSingle()
 	c.SetUpdater(ex)
+	c.Inspect()
 
 	ex.Align()
 	ui.Render(ex)


### PR DESCRIPTION
The PR is intended to improve performance and minimize expensive API calls.
Docker API has two methods: `ContainersList()` and more detailed `Inspect()`.
The ContainersList() has almost all needed fields except of ENV variables that are shown only in Inspect() response.
So the basic idea of the PR is: what if we'll try to get all fields from ContainersList() but when user opens Single View additionally make Inspect() call to get ENV variables. This also allows us to fetch here other things e.g. #226

Currently ctop works like:
1. When ctop starts it calls ContainersList() but extracts only `name`, registers a container and calls a separate Inspect() or each container to get all other fields.
2. When a new container created ctop receives `created` event and calls `Inspect()` to retrieve all fields and only then registers a container.

But in fact the only one container field shown in main view is container's name. All other fields are shown only in Single view.
And the `created` event already contains container's name and image. So we can just register a container directly from event.
But in future ctop may receive a new functionality to show other fields directly in main view (e.g. show `image` column). So let's keep the fetching of full info but use cheap ContainersList().

Also the PR has additional improvements: Refresh periodically each 5 minutes to remove non existing containers and bulk refresh.
