### PR TITLE
More columns

### DIFF
--- a/config/columns.go
+++ b/config/columns.go
@@ -6,47 +6,47 @@ import (
 
 // defaults
 var defaultColumns = []Column{
-	Column{
+	{
 		Name:    "status",
 		Label:   "Status Indicator",
 		Enabled: true,
 	},
-	Column{
+	{
 		Name:    "name",
 		Label:   "Container Name",
 		Enabled: true,
 	},
-	Column{
+	{
 		Name:    "id",
 		Label:   "Container ID",
 		Enabled: true,
 	},
-	Column{
+	{
 		Name:    "cpu",
 		Label:   "CPU Usage",
 		Enabled: true,
 	},
-	Column{
+	{
 		Name:    "cpus",
 		Label:   "CPU Usage (% of system total)",
 		Enabled: false,
 	},
-	Column{
+	{
 		Name:    "mem",
 		Label:   "Memory Usage",
 		Enabled: true,
 	},
-	Column{
+	{
 		Name:    "net",
 		Label:   "Network RX/TX",
 		Enabled: true,
 	},
-	Column{
+	{
 		Name:    "io",
 		Label:   "Disk IO Read/Write",
 		Enabled: true,
 	},
-	Column{
+	{
 		Name:    "pids",
 		Label:   "Container PID Count",
 		Enabled: true,

--- a/config/columns.go
+++ b/config/columns.go
@@ -22,6 +22,26 @@ var defaultColumns = []Column{
 		Enabled: true,
 	},
 	{
+		Name:    "image",
+		Label:   "Image name",
+		Enabled: false,
+	},
+	{
+		Name:    "ports",
+		Label:   "Exposed ports",
+		Enabled: false,
+	},
+	{
+		Name:    "IPs",
+		Label:   "Exposed IPs",
+		Enabled: false,
+	},
+	{
+		Name:    "created",
+		Label:   "Date created",
+		Enabled: false,
+	},
+	{
 		Name:    "cpu",
 		Label:   "CPU Usage",
 		Enabled: true,

--- a/cwidgets/compact/column.go
+++ b/cwidgets/compact/column.go
@@ -9,15 +9,19 @@ import (
 
 var (
 	allCols = map[string]NewCompactColFn{
-		"status": NewStatus,
-		"name":   NewNameCol,
-		"id":     NewCIDCol,
-		"cpu":    NewCPUCol,
-		"cpus":   NewCpuScaledCol,
-		"mem":    NewMemCol,
-		"net":    NewNetCol,
-		"io":     NewIOCol,
-		"pids":   NewPIDCol,
+		"status":  NewStatus,
+		"name":    NewNameCol,
+		"id":      NewCIDCol,
+		"image":   NewImageCol,
+		"ports":   NewPortsCol,
+		"IPs":     NewIpsCol,
+		"created": NewCreatedCol,
+		"cpu":     NewCPUCol,
+		"cpus":    NewCpuScaledCol,
+		"mem":     NewMemCol,
+		"net":     NewNetCol,
+		"io":      NewIOCol,
+		"pids":    NewPIDCol,
 	}
 )
 

--- a/cwidgets/compact/text.go
+++ b/cwidgets/compact/text.go
@@ -9,32 +9,26 @@ import (
 	ui "github.com/gizak/termui"
 )
 
-type NameCol struct {
+// Column that shows container's meta property i.e. name, id, image tc.
+type MetaCol struct {
 	*TextCol
+	metaName string
+}
+
+func (w *MetaCol) SetMeta(m models.Meta) {
+	w.setText(m.Get(w.metaName))
 }
 
 func NewNameCol() CompactCol {
-	c := &NameCol{NewTextCol("NAME")}
+	c := &MetaCol{NewTextCol("NAME"), "name"}
 	c.fWidth = 30
 	return c
 }
 
-func (w *NameCol) SetMeta(m models.Meta) {
-	w.setText(m.Get("name"))
-}
-
-type CIDCol struct {
-	*TextCol
-}
-
 func NewCIDCol() CompactCol {
-	c := &CIDCol{NewTextCol("CID")}
+	c := &MetaCol{NewTextCol("CID"), "id"}
 	c.fWidth = 12
 	return c
-}
-
-func (w *CIDCol) SetMeta(m models.Meta) {
-	w.setText(m.Get("id"))
 }
 
 type NetCol struct {

--- a/cwidgets/compact/text.go
+++ b/cwidgets/compact/text.go
@@ -31,6 +31,24 @@ func NewCIDCol() CompactCol {
 	return c
 }
 
+func NewImageCol() CompactCol {
+	return &MetaCol{NewTextCol("IMAGE"), "image"}
+}
+
+func NewPortsCol() CompactCol {
+	return &MetaCol{NewTextCol("PORTS"), "ports"}
+}
+
+func NewIpsCol() CompactCol {
+	return &MetaCol{NewTextCol("IPs"), "IPs"}
+}
+
+func NewCreatedCol() CompactCol {
+	c := &MetaCol{NewTextCol("CREATED"), "created"}
+	c.fWidth = 19 // Year will be stripped e.g. "Thu Nov 26 07:44:03" without 2020 at end
+	return c
+}
+
 type NetCol struct {
 	*TextCol
 }


### PR DESCRIPTION
![ctop mate-terminal light theme](https://user-images.githubusercontent.com/415502/101948922-863e6c00-3bfb-11eb-8550-5c0af421026d.png)
All the new columns are disabled by default.

TBD:
1. Ports column should be simplified i.e. just show published ports
2. Date created should be in more compact form