### PR TITLE
Fix cpu count estimation

### DIFF
--- a/connector/collector/docker.go
+++ b/connector/collector/docker.go
@@ -78,7 +78,7 @@ func (c *Docker) Stop() {
 func (c *Docker) ReadCPU(stats *api.Stats) {
 	ncpus := uint8(stats.CPUStats.OnlineCPUs)
 	if ncpus == 0 {
-	ncpus = uint8(len(stats.CPUStats.CPUUsage.PercpuUsage))
+		ncpus = uint8(len(stats.CPUStats.CPUUsage.PercpuUsage))
 	}
 	total := float64(stats.CPUStats.CPUUsage.TotalUsage)
 	system := float64(stats.CPUStats.SystemCPUUsage)

--- a/connector/collector/docker.go
+++ b/connector/collector/docker.go
@@ -76,10 +76,10 @@ func (c *Docker) Stop() {
 }
 
 func (c *Docker) ReadCPU(stats *api.Stats) {
-  ncpus := uint8(stats.CPUStats.OnlineCPUs)
-  if ncpus == 0 {
-    ncpus = uint8(len(stats.CPUStats.CPUUsage.PercpuUsage))
-  }
+	ncpus := uint8(stats.CPUStats.OnlineCPUs)
+	if ncpus == 0 {
+	ncpus = uint8(len(stats.CPUStats.CPUUsage.PercpuUsage))
+	}
 	total := float64(stats.CPUStats.CPUUsage.TotalUsage)
 	system := float64(stats.CPUStats.SystemCPUUsage)
 

--- a/connector/collector/docker.go
+++ b/connector/collector/docker.go
@@ -76,7 +76,10 @@ func (c *Docker) Stop() {
 }
 
 func (c *Docker) ReadCPU(stats *api.Stats) {
-	ncpus := uint8(len(stats.CPUStats.CPUUsage.PercpuUsage))
+  ncpus := uint8(stats.CPUStats.OnlineCPUs)
+  if ncpus == 0 {
+    ncpus = uint8(len(stats.CPUStats.CPUUsage.PercpuUsage))
+  }
 	total := float64(stats.CPUStats.CPUUsage.TotalUsage)
 	system := float64(stats.CPUStats.SystemCPUUsage)
 


### PR DESCRIPTION
Fixes the CPU utilization print in the overview.
It adapts the Docker api requests used to query the number of cpu cores which is needed for the estimation of the CPU utilization.
The used fix is similar to the one applied in `docker stats` which can be seen here:
https://github.com/docker/cli/blob/a32cd16160f1b41c1c4ae7bee4dac929d1484e59/cli/command/container/stats_helpers.go#L166

The pr closes issue #276. 

PR was tested locally with 

OS: Up to date Arch Linux
Docker Version: 20.10.12