### PR TITLE
Fix uptime calculation and formating 

### DIFF
--- a/connector/docker.go
+++ b/connector/docker.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/op/go-logging"
+  "github.com/hako/durafmt"
 
 	"github.com/bcicen/ctop/connector/collector"
 	"github.com/bcicen/ctop/connector/manager"
@@ -213,7 +214,7 @@ func calcUptime(insp *api.Container) string {
 		endTime = time.Now()
 	}
 	uptime := endTime.Sub(insp.State.StartedAt)
-	return uptime.Truncate(time.Second).String()
+  return durafmt.Parse(uptime).LimitFirstN(1).String()
 }
 
 // Mark all container IDs for refresh

--- a/connector/docker.go
+++ b/connector/docker.go
@@ -187,7 +187,7 @@ func (cm *Docker) refresh(c *container.Container) {
 	if webPort != "" {
 		c.SetMeta("Web Port", webPort)
 	}
-	c.SetMeta("created", insp.Created.Format("Mon Jan 2 15:04:05 2006"))
+	c.SetMeta("created", insp.Created.Format("Mon Jan 02 15:04:05 2006"))
 	c.SetMeta("uptime", calcUptime(insp))
 	c.SetMeta("health", insp.State.Health.Status)
 	c.SetMeta("[ENV-VAR]", strings.Join(insp.Config.Env, ";"))

--- a/connector/docker.go
+++ b/connector/docker.go
@@ -209,7 +209,7 @@ func (cm *Docker) inspect(id string) (insp *api.Container, found bool, failed bo
 
 func calcUptime(insp *api.Container) string {
 	endTime := insp.State.FinishedAt
-	if endTime.IsZero() {
+	if endTime.IsZero() || insp.State.Running {
 		endTime = time.Now()
 	}
 	uptime := endTime.Sub(insp.State.StartedAt)

--- a/connector/docker.go
+++ b/connector/docker.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/op/go-logging"
-  "github.com/hako/durafmt"
+	"github.com/hako/durafmt"
 
 	"github.com/bcicen/ctop/connector/collector"
 	"github.com/bcicen/ctop/connector/manager"
@@ -214,7 +214,7 @@ func calcUptime(insp *api.Container) string {
 		endTime = time.Now()
 	}
 	uptime := endTime.Sub(insp.State.StartedAt)
-  return durafmt.Parse(uptime).LimitFirstN(1).String()
+	return durafmt.Parse(uptime).LimitFirstN(1).String()
 }
 
 // Mark all container IDs for refresh

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/c9s/goprocinfo v0.0.0-20170609001544-b34328d6e0cd
 	github.com/fsouza/go-dockerclient v1.7.0
 	github.com/gizak/termui v2.3.0+incompatible
+	github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b // indirect
 	github.com/jgautheron/codename-generator v0.0.0-20150829203204-16d037c7cc3c
 	github.com/mattn/go-runewidth v0.0.0-20170201023540-14207d285c6c
 	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b h1:wDUNC2eKiL35DbLvsDhiblTUXHxcOPwQSCzi7xpQUN4=
+github.com/hako/durafmt v0.0.0-20210608085754-5c1018a4e16b/go.mod h1:VzxiSdG6j1pi7rwGm/xYI5RbtpBgM8sARDXlvEvxlu0=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=


### PR DESCRIPTION
This PR adds the fix suggested by @dricottone in #275.

In addition to that, a new formating is introduced to only show the most important magnitude for the duration (e.g. hide seconds most of the time). This helps with readability and reduces wrong second displays due to a low update rate.
Due to the limited capabilities of the duration formatting in the standard library, the dependency https://github.com/hako/durafmt is added.

Another minor fix includes displaying a leading zero in the creation date to align the indentation.

Cheers

Demo:
![image](https://user-images.githubusercontent.com/15075613/151891004-cfd87720-5531-441d-b56d-e27a1fb4f849.png)

Fixes #275

PR was tested locally with

OS: Up to date Arch Linux
Docker Version: 20.10.12