### PR TITLE
Fix apt-key is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Fetch the [latest release](https://github.com/bcicen/ctop/releases) for your pla
 
 Maintained by a [third party](https://packages.azlux.fr/)
 ```bash
+sudo apt-get install ca-certificates curl gnupg lsb-release
 curl -fsSL https://azlux.fr/repo.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/azlux-archive-keyring.gpg
 echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/azlux-archive-keyring.gpg] http://packages.azlux.fr/debian \

--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ Fetch the [latest release](https://github.com/bcicen/ctop/releases) for your pla
 
 Maintained by a [third party](https://packages.azlux.fr/)
 ```bash
-echo "deb http://packages.azlux.fr/debian/ buster main" | sudo tee /etc/apt/sources.list.d/azlux.list
-wget -qO - https://azlux.fr/repo.gpg.key | sudo apt-key add -
-sudo apt update
-sudo apt install docker-ctop
+curl -fsSL https://azlux.fr/repo.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/azlux-archive-keyring.gpg
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/azlux-archive-keyring.gpg] http://packages.azlux.fr/debian \
+  $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/azlux.list >/dev/null
+sudo apt-get update
+sudo apt-get install docker-ctop
 ```
 
 #### Arch


### PR DESCRIPTION
The management utility apt-key has been deprecated for Debian and Ubuntu:
http://manpages.ubuntu.com/manpages/impish/man8/apt-key.8.html
 
I also added the required packages to add the keyring.

Fix #298