### PR TITLE
Update README.md: fix Debian/Ubuntu installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ sudo apt-get install ca-certificates curl gnupg lsb-release
 curl -fsSL https://azlux.fr/repo.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/azlux-archive-keyring.gpg
 echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/azlux-archive-keyring.gpg] http://packages.azlux.fr/debian \
-  $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/azlux.list >/dev/null
+  stable main" | sudo tee /etc/apt/sources.list.d/azlux.list >/dev/null
 sudo apt-get update
 sudo apt-get install docker-ctop
 ```


### PR DESCRIPTION
As explained in issue https://github.com/bcicen/ctop/issues/179, jammy (Ubuntu 22.04.2 LTS) is unknown from the `azlux.fr` repo and **it will prevent people from installing** `ctop` on `Ubuntu 22.04` and later.

Also we can see in the script http://packages.azlux.fr/scripts/docker-ctop.txt that the only provided version is the `stabe` version.

So we should use `stable` in the installation commands.