### PR TITLE
Fix Ubuntu package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/azlux-archive-keyring.gpg] http://packages.azlux.fr/debian \
   $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/azlux.list >/dev/null
 sudo apt-get update
-sudo apt-get install docker-ctop
+sudo apt-get install ctop
 ```
 
 #### Arch


### PR DESCRIPTION
Seems that the Ubuntu package name has changes from `docker-ctop` to just `ctop`:

```
$ sudo apt-get install docker-ctop
[sudo] password for dloos: 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package docker-ctop
$ sudo apt-get install ctop
Reading package lists... Done
Building dependency tree       
Reading state information... Done
ctop is already the newest version (1.0.0-2).
The following packages were automatically installed and are no longer required:
  apt-clone archdetect-deb dmraid docker-scan-plugin gir1.2-goa-1.0 gir1.2-timezonemap-1.0 gir1.2-xkl-1.0 kpartx kpartx-boot libdap-dev libdapserver7v5
  libdebian-installer4 libdmraid1.0.0.rc16 libepsilon-dev libgeos-3.8.0 libpcre16-3 libpcre3-dev libpcre32-3 libpcrecpp0v5 libtimezonemap-data libtimezonemap1
  libv4l2rds0 libxmlb1 oem-fix-cam-intel-mipi-ipu6-common oem-fix-cam-intel-mipi-ipu6ep python3-icu python3-pam rdate uuid-dev v4l-utils
Use 'sudo apt autoremove' to remove them.
0 upgraded, 0 newly installed, 0 to remove and 1 not upgraded.
```