### PR TITLE
docs: persistent configuration in Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ scoop install ctop
 docker run --rm -ti \
   --name=ctop \
   --volume /var/run/docker.sock:/var/run/docker.sock:ro \
+  -e XDG_CONFIG_HOME=/conf \
+  -v /custom/ctop_conf/:/conf/ctop/ \
   quay.io/vektorlab/ctop:latest
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ docker run --rm -ti \
   --name=ctop \
   --volume /var/run/docker.sock:/var/run/docker.sock:ro \
   -e XDG_CONFIG_HOME=/conf \
-  -v /custom/ctop_conf/:/conf/ctop/ \
+  -v ctop_conf:/conf/ctop/ \
   quay.io/vektorlab/ctop:latest
 ```
 


### PR DESCRIPTION
So that the configuration is persisted on the host when running `ctop` with Docker.