### PR TITLE
Fix I/O stats showing 0/0 on cgroup v2 hosts

### DIFF
--- a/connector/collector/docker.go
+++ b/connector/collector/docker.go
@@ -1,6 +1,8 @@
 package collector
 
 import (
+	"strings"
+
 	"github.com/bcicen/ctop/models"
 	api "github.com/fsouza/go-dockerclient"
 )
@@ -111,10 +113,13 @@ func (c *Docker) ReadNet(stats *api.Stats) {
 func (c *Docker) ReadIO(stats *api.Stats) {
 	var read, write int64
 	for _, blk := range stats.BlkioStats.IOServiceBytesRecursive {
-		if blk.Op == "Read" {
+		// cgroup v1 reports the operation as "Read"/"Write", while cgroup v2
+		// reports it lowercase as "read"/"write". Match case-insensitively so
+		// I/O stats are populated on both (otherwise cgroup v2 hosts show 0/0).
+		if strings.EqualFold(blk.Op, "Read") {
 			read += int64(blk.Value)
 		}
-		if blk.Op == "Write" {
+		if strings.EqualFold(blk.Op, "Write") {
 			write += int64(blk.Value)
 		}
 	}


### PR DESCRIPTION
## Problem

On cgroup v2 hosts, every container's IO column shows `0 / 0` regardless of actual disk activity, while `docker stats` reports correct Block I/O for the same containers.

## Cause

The Docker stats API reports the blkio operation name differently between cgroup versions:

- cgroup v1: `"Read"` / `"Write"` (capitalized)
- cgroup v2: `"read"` / `"write"` (lowercase)

`ReadIO` in `connector/collector/docker.go` compared `blk.Op` with case-sensitive equality (`== "Read"` / `== "Write"`), so on cgroup v2 neither branch ever matches and the read/write totals stay at zero.

Raw API sample from a cgroup v2 host (`io_service_bytes_recursive`):

```json
{ "major": 259, "minor": 0, "op": "read",  "value": 4096 }
{ "major": 259, "minor": 0, "op": "write", "value": 1781760 }
```

## Fix

Compare the operation case-insensitively with `strings.EqualFold`, so the values populate correctly on both cgroup v1 and v2. No behavior change on cgroup v1.

## Testing

Verified on a Docker 27.5.1 host with cgroup v2 (systemd driver). After the change, ctop's IO read/write match `docker stats` Block I/O for the same containers.